### PR TITLE
Add IL2CPP config for IL2CPP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains IDEs
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ FodyWeavers.xsd
 
 # JetBrains IDEs
 .idea/
+
+# Local dev-specific build props overrides
+local.build.props

--- a/EasyPlanting.sln
+++ b/EasyPlanting.sln
@@ -7,14 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyPlanting", "EasyPlantin
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Mono|Any CPU = Mono|Any CPU
+		IL2CPP|Any CPU = IL2CPP|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Mono|Any CPU.ActiveCfg = Mono|Any CPU
+		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.Mono|Any CPU.Build.0 = Mono|Any CPU
+		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.IL2CPP|Any CPU.ActiveCfg = IL2CPP|Any CPU
+		{B03FA9F3-A62E-4031-A510-7E06AAD523BB}.IL2CPP|Any CPU.Build.0 = IL2CPP|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/EasyPlanting/EasyPlanting.csproj
+++ b/EasyPlanting/EasyPlanting.csproj
@@ -75,7 +75,7 @@
         <PackageReference Include="LavaGang.MelonLoader" Version="0.7.0"/>
     </ItemGroup>
 
-    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToDeploymentPath)' == 'true'">
         <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;D:\SteamLibrary\steamapps\common\Schedule I - Mono\Mods&quot;"/>
     </Target>
 

--- a/EasyPlanting/EasyPlanting.csproj
+++ b/EasyPlanting/EasyPlanting.csproj
@@ -35,18 +35,10 @@
     <!-- IL2CPP Specific Dependencies -->
     <ItemGroup Condition="'$(Configuration)' == 'IL2CPP'">
         <Reference Include="$(Il2CppAssembliesPath)\Assembly-CSharp.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\Il2CppFishNet.Runtime.dll"/>
         <Reference Include="$(Il2CppAssembliesPath)\Il2Cppmscorlib.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\Il2CpNewtonsoft.Json.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.dll"/>
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.CoreModule.dll"/>
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.ImageConversionModule.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.InputLegacyModule.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.JSONSerializeModule.dll"/>
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.PhysicsModule.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.TextRenderingModule.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.UI.dll"/>
-        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.UIModule.dll"/>
 
         <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Common.dll"/>
         <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Generator.dll"/>
@@ -57,17 +49,9 @@
     <!-- Mono Specific Dependencies -->
     <ItemGroup Condition="'$(Configuration)' == 'Mono'">
         <Reference Include="$(MonoAssembliesPath)\Assembly-CSharp.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\FishNet.Runtime.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\Newtonsoft.Json.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.dll"/>
         <Reference Include="$(MonoAssembliesPath)\UnityEngine.CoreModule.dll"/>
         <Reference Include="$(MonoAssembliesPath)\UnityEngine.ImageConversionModule.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.InputLegacyModule.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.JSONSerializeModule.dll"/>
         <Reference Include="$(MonoAssembliesPath)\UnityEngine.PhysicsModule.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.TextRenderingModule.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.UI.dll"/>
-        <Reference Include="$(MonoAssembliesPath)\UnityEngine.UIModule.dll"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/EasyPlanting/EasyPlanting.csproj
+++ b/EasyPlanting/EasyPlanting.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RunPostBuildEvent>Always</RunPostBuildEvent>

--- a/EasyPlanting/EasyPlanting.csproj
+++ b/EasyPlanting/EasyPlanting.csproj
@@ -1,62 +1,83 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <RunPostBuildEvent>Always</RunPostBuildEvent>
-    <LangVersion>10.0</LangVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RunPostBuildEvent>Always</RunPostBuildEvent>
+        <LangVersion>10.0</LangVersion>
+        <Version>$(Version)</Version>
+        <Configurations>IL2CPP;Mono</Configurations>
+        <Platforms>AnyCPU</Platforms>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="Resources\IconBad.png" />
-    <None Remove="Resources\IconGood.png" />
-    <None Remove="Resources\IconWarn.png" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Remove="Resources\IconBad.png"/>
+        <None Remove="Resources\IconGood.png"/>
+        <None Remove="Resources\IconWarn.png"/>
+        <EmbeddedResource Include="Resources\IconBad.png"/>
+        <EmbeddedResource Include="Resources\IconGood.png"/>
+        <EmbeddedResource Include="Resources\IconWarn.png"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\IconBad.png" />
-    <EmbeddedResource Include="Resources\IconGood.png" />
-    <EmbeddedResource Include="Resources\IconWarn.png" />
-  </ItemGroup>
+    <!-- Imports build properties for developers using Thunderstore Mod Manager. -->
+    <Import Project="../thunderstore.build.props" Condition="Exists('../thunderstore.build.props')"/>
+    <!-- Imports dev-specific build props directories. -->
+    <Import Project="../local.build.props" Condition="Exists('../local.build.props')"/>
 
-  <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
-    <Reference Include="0Harmony">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\MelonLoader\net6\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\Assembly-CSharp.dll" Publicize="true" />
-    <Reference Include="FishNet.Runtime">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\FishNet.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="MelonLoader">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\MelonLoader\net35\MelonLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\MelonLoader\net6\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+    <PropertyGroup Condition="'$(Configuration)' == 'IL2CPP'">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;D:\SteamLibrary\steamapps\common\Schedule I - Mono\Mods&quot;" />
-  </Target>
+    <PropertyGroup Condition="'$(Configuration)' == 'Mono'">
+        <TargetFramework>netstandard2.1</TargetFramework>
+    </PropertyGroup>
+
+    <!-- IL2CPP Specific Dependencies -->
+    <ItemGroup Condition="'$(Configuration)' == 'IL2CPP'">
+        <Reference Include="$(Il2CppAssembliesPath)\Assembly-CSharp.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\Il2CppFishNet.Runtime.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\Il2Cppmscorlib.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\Il2CpNewtonsoft.Json.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.CoreModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.ImageConversionModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.InputLegacyModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.JSONSerializeModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.PhysicsModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.TextRenderingModule.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.UI.dll"/>
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.UIModule.dll"/>
+
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Common.dll"/>
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Generator.dll"/>
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.HarmonySupport.dll"/>
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Runtime.dll"/>
+    </ItemGroup>
+
+    <!-- Mono Specific Dependencies -->
+    <ItemGroup Condition="'$(Configuration)' == 'Mono'">
+        <Reference Include="$(MonoAssembliesPath)\Assembly-CSharp.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\FishNet.Runtime.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\Newtonsoft.Json.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.CoreModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.ImageConversionModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.InputLegacyModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.JSONSerializeModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.PhysicsModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.TextRenderingModule.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.UI.dll"/>
+        <Reference Include="$(MonoAssembliesPath)\UnityEngine.UIModule.dll"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HarmonyX" Version="2.14.0"/>
+        <PackageReference Include="LavaGang.MelonLoader" Version="0.7.0"/>
+    </ItemGroup>
+
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;D:\SteamLibrary\steamapps\common\Schedule I - Mono\Mods&quot;"/>
+    </Target>
 
 </Project>

--- a/EasyPlanting/ModMain.cs
+++ b/EasyPlanting/ModMain.cs
@@ -1,16 +1,19 @@
 ﻿using EasyPlanting;
 using EasyPlanting.Product;
-using EasyPlanting.Utils;
 using MelonLoader;
-using MelonLoader.Utils;
+using UnityEngine;
+
+#if IL2CPP
+using Il2CppScheduleOne;
+using Il2CppScheduleOne.DevUtilities;
+using Il2CppScheduleOne.Growing;
+using Il2CppScheduleOne.PlayerTasks;
+#elif MONO
 using ScheduleOne;
 using ScheduleOne.DevUtilities;
-using ScheduleOne.Dragging;
 using ScheduleOne.Growing;
 using ScheduleOne.PlayerTasks;
-using ScheduleOne.UI;
-using System.Reflection;
-using UnityEngine;
+#endif
 
 
 [assembly: MelonInfo(typeof(ModMain), BuildInfo.ProductName, BuildInfo.ProductVersion, BuildInfo.ProductAuthor, BuildInfo.ProductLink)]

--- a/EasyPlanting/Patches/DraggablePatches.cs
+++ b/EasyPlanting/Patches/DraggablePatches.cs
@@ -1,10 +1,14 @@
 ﻿using HarmonyLib;
+
+#if IL2CPP
+using Il2CppScheduleOne.PlayerTasks;
+#elif MONO
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Growing;
+using ScheduleOne.ObjectScripts.Soil;
 using ScheduleOne.PlayerTasks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#endif
 
 namespace EasyPlanting.Patches
 {

--- a/EasyPlanting/Patches/DraggablePatches.cs
+++ b/EasyPlanting/Patches/DraggablePatches.cs
@@ -3,10 +3,6 @@
 #if IL2CPP
 using Il2CppScheduleOne.PlayerTasks;
 #elif MONO
-using ScheduleOne;
-using ScheduleOne.DevUtilities;
-using ScheduleOne.Growing;
-using ScheduleOne.ObjectScripts.Soil;
 using ScheduleOne.PlayerTasks;
 #endif
 

--- a/EasyPlanting/Patches/PlantHarvestablePatches.cs
+++ b/EasyPlanting/Patches/PlantHarvestablePatches.cs
@@ -1,10 +1,16 @@
 ﻿using HarmonyLib;
 using MelonLoader;
-using ScheduleOne.Growing;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
+
+#if IL2CPP
+using Il2CppScheduleOne.Growing;
+#elif MONO
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Growing;
+using ScheduleOne.ObjectScripts.Soil;
+using ScheduleOne.PlayerTasks;
+#endif
 
 namespace EasyPlanting.Patches
 {

--- a/EasyPlanting/Patches/PlantHarvestablePatches.cs
+++ b/EasyPlanting/Patches/PlantHarvestablePatches.cs
@@ -5,11 +5,7 @@ using UnityEngine;
 #if IL2CPP
 using Il2CppScheduleOne.Growing;
 #elif MONO
-using ScheduleOne;
-using ScheduleOne.DevUtilities;
 using ScheduleOne.Growing;
-using ScheduleOne.ObjectScripts.Soil;
-using ScheduleOne.PlayerTasks;
 #endif
 
 namespace EasyPlanting.Patches

--- a/EasyPlanting/Patches/PourWaterTask.cs
+++ b/EasyPlanting/Patches/PourWaterTask.cs
@@ -6,12 +6,8 @@ using Il2CppScheduleOne.ObjectScripts;
 using Il2CppScheduleOne.PlayerTasks;
 using Il2CppScheduleOne.PlayerTasks.Tasks;
 #elif MONO
-using ScheduleOne;
-using ScheduleOne.DevUtilities;
-using ScheduleOne.Growing;
 using ScheduleOne.ItemFramework;
 using ScheduleOne.ObjectScripts;
-using ScheduleOne.ObjectScripts.Soil;
 using ScheduleOne.PlayerTasks;
 using ScheduleOne.PlayerTasks.Tasks;
 #endif

--- a/EasyPlanting/Patches/PourWaterTask.cs
+++ b/EasyPlanting/Patches/PourWaterTask.cs
@@ -1,13 +1,20 @@
 ﻿using HarmonyLib;
+
+#if IL2CPP
+using Il2CppScheduleOne.ItemFramework;
+using Il2CppScheduleOne.ObjectScripts;
+using Il2CppScheduleOne.PlayerTasks;
+using Il2CppScheduleOne.PlayerTasks.Tasks;
+#elif MONO
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Growing;
 using ScheduleOne.ItemFramework;
 using ScheduleOne.ObjectScripts;
 using ScheduleOne.ObjectScripts.Soil;
 using ScheduleOne.PlayerTasks;
 using ScheduleOne.PlayerTasks.Tasks;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
+#endif
 
 namespace EasyPlanting.Patches
 {

--- a/EasyPlanting/Patches/PourableSoilPatches.cs
+++ b/EasyPlanting/Patches/PourableSoilPatches.cs
@@ -1,12 +1,17 @@
 ﻿using HarmonyLib;
+
+#if IL2CPP
+using Il2CppScheduleOne.ObjectScripts.Soil;
+#elif MONO
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Growing;
 using ScheduleOne.ObjectScripts.Soil;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using ScheduleOne.PlayerTasks;
+#endif
 
 namespace EasyPlanting.Patches
 {
-
     [HarmonyPatch(typeof(PourableSoil))]
     public class PourableSoilPatches
     {

--- a/EasyPlanting/Patches/PourableSoilPatches.cs
+++ b/EasyPlanting/Patches/PourableSoilPatches.cs
@@ -3,11 +3,7 @@
 #if IL2CPP
 using Il2CppScheduleOne.ObjectScripts.Soil;
 #elif MONO
-using ScheduleOne;
-using ScheduleOne.DevUtilities;
-using ScheduleOne.Growing;
 using ScheduleOne.ObjectScripts.Soil;
-using ScheduleOne.PlayerTasks;
 #endif
 
 namespace EasyPlanting.Patches

--- a/EasyPlanting/Product/BuildInfo.cs
+++ b/EasyPlanting/Product/BuildInfo.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace EasyPlanting.Product
+﻿namespace EasyPlanting.Product
 {
     public static class BuildInfo
     {

--- a/EasyPlanting/Settings/Config.cs
+++ b/EasyPlanting/Settings/Config.cs
@@ -1,7 +1,5 @@
 ﻿using EasyPlanting.Utils;
 using MelonLoader;
-using MelonLoader.Utils;
-using Newtonsoft.Json;
 using System.Reflection;
 
 namespace EasyPlanting

--- a/EasyPlanting/Utils/Embedded.cs
+++ b/EasyPlanting/Utils/Embedded.cs
@@ -1,8 +1,5 @@
 ﻿using MelonLoader;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using UnityEngine;
 
 namespace EasyPlanting.Utils

--- a/EasyPlanting/Utils/NotificationUtils.cs
+++ b/EasyPlanting/Utils/NotificationUtils.cs
@@ -1,10 +1,20 @@
 ﻿using MelonLoader;
-using ScheduleOne.DevUtilities;
-using ScheduleOne.UI;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
+
+#if IL2CPP
+using Il2CppScheduleOne.DevUtilities;
+using Il2CppScheduleOne.UI;
+#elif MONO
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Growing;
+using ScheduleOne.ItemFramework;
+using ScheduleOne.ObjectScripts;
+using ScheduleOne.ObjectScripts.Soil;
+using ScheduleOne.PlayerTasks;
+using ScheduleOne.PlayerTasks.Tasks;
+using ScheduleOne.UI;
+#endif
 
 namespace EasyPlanting.Utils
 {

--- a/EasyPlanting/Utils/NotificationUtils.cs
+++ b/EasyPlanting/Utils/NotificationUtils.cs
@@ -5,14 +5,7 @@ using UnityEngine;
 using Il2CppScheduleOne.DevUtilities;
 using Il2CppScheduleOne.UI;
 #elif MONO
-using ScheduleOne;
 using ScheduleOne.DevUtilities;
-using ScheduleOne.Growing;
-using ScheduleOne.ItemFramework;
-using ScheduleOne.ObjectScripts;
-using ScheduleOne.ObjectScripts.Soil;
-using ScheduleOne.PlayerTasks;
-using ScheduleOne.PlayerTasks.Tasks;
 using ScheduleOne.UI;
 #endif
 

--- a/EasyPlanting/Utils/ReloadRequiredAttribute.cs
+++ b/EasyPlanting/Utils/ReloadRequiredAttribute.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace EasyPlanting.Utils
+﻿namespace EasyPlanting.Utils
 {
     [AttributeUsage(AttributeTargets.Field)]
     public class ReloadRequiredAttribute : Attribute { }

--- a/local.build.props
+++ b/local.build.props
@@ -1,0 +1,20 @@
+<Project>
+    <PropertyGroup>
+        <!-- Used when building both Il2Cpp and Mono. Typically located at `steamapps/Schedule I/MelonLoader/net6` -->
+        <MelonLoaderAssembliesPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\MelonLoader\net6</MelonLoaderAssembliesPath>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(Configuration)' == 'IL2CPP'">
+        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I` -->
+        <LocalIl2CppDeploymentPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\Mods</LocalIl2CppDeploymentPath>
+        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I/MelonLoader/Il2CppAssemblies` -->
+        <Il2CppAssembliesPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\Mods\MelonLoader\Il2CppAssemblies</Il2CppAssembliesPath>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(Configuration)' == 'Mono'">
+        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I` -->
+        <LocalMonoDeploymentPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\Mods</LocalMonoDeploymentPath>
+        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I/Schedule I_Data/Managed` -->
+        <MonoAssembliesPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I Mono\Schedule I_Data\Managed</MonoAssembliesPath>
+    </PropertyGroup>
+</Project>

--- a/thunderstore.build.props
+++ b/thunderstore.build.props
@@ -1,0 +1,20 @@
+<Project>
+    <PropertyGroup>
+        <!-- Used when building both Il2Cpp and Mono. Typically located at `steamapps/Schedule I/MelonLoader/net6` -->
+        <MelonLoaderAssembliesPath>$(AppData)\Thunderstore Mod Manager\DataFolder\ScheduleI\profiles\Default\MelonLoader\net6</MelonLoaderAssembliesPath>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(Configuration)' == 'IL2CPP'">
+        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I` -->
+        <LocalIl2CppDeploymentPath>$(AppData)\Thunderstore Mod Manager\DataFolder\ScheduleI\profiles\Default</LocalIl2CppDeploymentPath>
+        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I/MelonLoader/Il2CppAssemblies` -->
+        <Il2CppAssembliesPath>$(AppData)\Thunderstore Mod Manager\DataFolder\ScheduleI\profiles\Default\MelonLoader\Il2CppAssemblies</Il2CppAssembliesPath>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(Configuration)' == 'Mono'">
+        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I` -->
+        <LocalMonoDeploymentPath>$(AppData)\Thunderstore Mod Manager\DataFolder\ScheduleI\profiles\Default</LocalMonoDeploymentPath>
+        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I/Schedule I_Data/Managed` -->
+        <MonoAssembliesPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\Schedule I_Data\Managed</MonoAssembliesPath>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Add IL2CPP build config that will compile the code for the IL2CPP version of the game.

@joeswagson Here is what you should put in your `local.build.props` file so that your custom config is still working. It should work at least. :) Hard for me to test.

```xml
<Project>
    <PropertyGroup>
        <!-- Used when building both Il2Cpp and Mono. Typically located at `steamapps/Schedule I/MelonLoader/net6` -->
        <MelonLoaderAssembliesPath>C:\Program Files (x86)\Steam\steamapps\common\Schedule I\MelonLoader\net6</MelonLoaderAssembliesPath>
        <CopyToDeploymentPath>true</CopyToDeploymentPath>
    </PropertyGroup>
    
    <PropertyGroup Condition="'$(Configuration)' == 'IL2CPP'">
        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I` -->
        <LocalIl2CppDeploymentPath>D:\SteamLibrary\steamapps\common\Schedule I\Mods</LocalIl2CppDeploymentPath>
        <!-- Used only when building against IL2CPP. Typically located at `steamapps/Schedule I/MelonLoader/Il2CppAssemblies` -->
        <Il2CppAssembliesPath>D:\SteamLibrary\steamapps\common\Schedule I\Mods\MelonLoader\Il2CppAssemblies</Il2CppAssembliesPath>
    </PropertyGroup>
    
    <PropertyGroup Condition="'$(Configuration)' == 'Mono'">
        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I` -->
        <LocalMonoDeploymentPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Mods</LocalMonoDeploymentPath>
        <!-- Used only when building against Mono. Typically located at `steamapps/Schedule I/Schedule I_Data/Managed` -->
        <MonoAssembliesPath>D:\SteamLibrary\steamapps\common\Schedule I - Mono\Schedule I_Data\Managed</MonoAssembliesPath>
    </PropertyGroup>
</Project>
```